### PR TITLE
Default viewport vector to all zeroes

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
     <script src="xrmp.js"></script>
     <script src="xrmp-three.js"></script>
     <script>
-let display, fakeXrDisplay, tabs = [], tabId = 0, xrmp, lastPresseds = [false, false], lastAxes = [[0.5, 0.5], [0.5, 0.5]], lastPadToucheds = [false, false], scrollFactors = [0, 0], scaleFactors = [1, 1], viewport = new THREE.Vector4(), menuOpen = false, orbitControls, transformControls;
+let display, fakeXrDisplay, tabs = [], tabId = 0, xrmp, lastPresseds = [false, false], lastAxes = [[0.5, 0.5], [0.5, 0.5]], lastPadToucheds = [false, false], scrollFactors = [0, 0], scaleFactors = [1, 1], viewport = new THREE.Vector4(0, 0, 0, 0), menuOpen = false, orbitControls, transformControls;
 
 const links = [
   {


### PR DESCRIPTION
This was partly responsible for the Studio glitching on startup.

The viewport started as (0, 0, 0, 1), making for an initial upside-down render of the vr view. Zeroing it makes it so there is no render until the viewport is explicitly set by the HTML page loading.