### PR TITLE
Engine render green screen

### DIFF
--- a/ui/src/css/engine.css
+++ b/ui/src/css/engine.css
@@ -202,5 +202,5 @@
 }
 #Engine .engine-render {
   flex: 1;
-  background-color: #000;
+  background-color: #0F0;
 }


### PR DESCRIPTION
This makes the engine render placeholder slot in the studio UI render as green (`#0F0`).

The purpose of this -- in addition to easier debugging -- is to enable shader-based composition of the HTML UI and our viewport.

Work towards https://github.com/exokitxr/studio/issues/12.