### PR TITLE
Remove console resizing

### DIFF
--- a/ui/src/components/Engine.jsx
+++ b/ui/src/components/Engine.jsx
@@ -28,6 +28,7 @@ class Engine extends React.Component {
         urlFocus: false,
         addTab: 'template',
         url: 'https://aframe.io/a-painter/',
+        minHeight: 0,
       };
     }
 
@@ -218,9 +219,15 @@ class Engine extends React.Component {
         consoleOpen: !this.state.consoleOpen,
       });
       if(this.state.consoleOpen){
-        this.resizable.updateSize({ height: 0, maxHeight: 0 });
+        this.resizable.updateSize({ height: 0 });
+        this.setState({
+          minHeight: 0,
+        });
       } else {
-        this.resizable.updateSize({ height: 150, minHeight: 150 });
+        this.resizable.updateSize({ height: 150 });
+        this.setState({
+          minHeight: 150,
+        });
       }
     }
 
@@ -351,6 +358,7 @@ class Engine extends React.Component {
               <Resizable
                 ref={c => { this.resizable = c; }}
                 minWidth="200px"
+                minHeight={this.state.minHeight}
                 onResize={(e, direction, ref, d) => {
                   _postViewportMessage();
                 }}>

--- a/ui/src/components/Engine.jsx
+++ b/ui/src/components/Engine.jsx
@@ -217,6 +217,11 @@ class Engine extends React.Component {
       this.setState({
         consoleOpen: !this.state.consoleOpen,
       });
+      if(this.state.consoleOpen){
+        this.resizable.updateSize({ height: 0, maxHeight: 0 });
+      } else {
+        this.resizable.updateSize({ height: 150, minHeight: 150 });
+      }
     }
 
     blur() {
@@ -344,6 +349,7 @@ class Engine extends React.Component {
             <div className="engine-left">
               <div className="engine-render" id="engine-render" onClick={() => this.onEngineRenderClick()} />
               <Resizable
+                ref={c => { this.resizable = c; }}
                 minWidth="200px"
                 onResize={(e, direction, ref, d) => {
                   _postViewportMessage();

--- a/ui/src/components/Engine.jsx
+++ b/ui/src/components/Engine.jsx
@@ -343,15 +343,7 @@ class Engine extends React.Component {
           <div className="engine-split">
             <div className="engine-left">
               <div className="engine-render" id="engine-render" onClick={() => this.onEngineRenderClick()} />
-              <Resizable
-                minWidth="200px"
-                // minHeight="100px"
-                // maxHeight="300px"
-                onResize={(e, direction, ref, d) => {
-                  _postViewportMessage();
-                }}>
-                <Console open={this.state.consoleOpen} postViewportMessage={this.postViewportMessage} />
-              </Resizable>
+              <Console open={this.state.consoleOpen} postViewportMessage={this.postViewportMessage} />
             </div>
             <Resizable
               minWidth="200px"

--- a/ui/src/components/Engine.jsx
+++ b/ui/src/components/Engine.jsx
@@ -344,7 +344,6 @@ class Engine extends React.Component {
             <div className="engine-left">
               <div className="engine-render" id="engine-render" onClick={() => this.onEngineRenderClick()} />
               <Resizable
-                ref={c => { this.resizable = c; }}
                 minWidth="200px"
                 minHeight={this.state.consoleOpen ? 150 : 0}
                 onResize={(e, direction, ref, d) => {

--- a/ui/src/components/Engine.jsx
+++ b/ui/src/components/Engine.jsx
@@ -343,7 +343,13 @@ class Engine extends React.Component {
           <div className="engine-split">
             <div className="engine-left">
               <div className="engine-render" id="engine-render" onClick={() => this.onEngineRenderClick()} />
-              <Console open={this.state.consoleOpen} postViewportMessage={this.postViewportMessage} />
+              <Resizable
+                minWidth="200px"
+                onResize={(e, direction, ref, d) => {
+                  _postViewportMessage();
+                }}>
+                <Console open={this.state.consoleOpen} postViewportMessage={this.postViewportMessage} />
+              </Resizable>
             </div>
             <Resizable
               minWidth="200px"

--- a/ui/src/components/Engine.jsx
+++ b/ui/src/components/Engine.jsx
@@ -28,7 +28,6 @@ class Engine extends React.Component {
         urlFocus: false,
         addTab: 'template',
         url: 'https://aframe.io/a-painter/',
-        minHeight: 0,
       };
     }
 
@@ -218,17 +217,6 @@ class Engine extends React.Component {
       this.setState({
         consoleOpen: !this.state.consoleOpen,
       });
-      if(this.state.consoleOpen){
-        this.resizable.updateSize({ height: 0 });
-        this.setState({
-          minHeight: 0,
-        });
-      } else {
-        this.resizable.updateSize({ height: 150 });
-        this.setState({
-          minHeight: 150,
-        });
-      }
     }
 
     blur() {
@@ -358,7 +346,7 @@ class Engine extends React.Component {
               <Resizable
                 ref={c => { this.resizable = c; }}
                 minWidth="200px"
-                minHeight={this.state.minHeight}
+                minHeight={this.state.consoleOpen ? 150 : 0}
                 onResize={(e, direction, ref, d) => {
                   _postViewportMessage();
                 }}>

--- a/ui/src/css/console.css
+++ b/ui/src/css/console.css
@@ -1,6 +1,6 @@
 .Console {
   position: relative;
-  height: 0px;
+  max-height: 0px;
   border-top: 2px solid #222;
   font-family: monospace;
   font-size: 11px;
@@ -13,7 +13,9 @@
   justify-content:space-between;
 }
 .Console.open {
-  height: 30%;
+  height: 100%;
+  max-height: 100%;
+  min-height: 150px;
 }
 
 .Console .console-output {

--- a/ui/src/css/console.css
+++ b/ui/src/css/console.css
@@ -7,6 +7,10 @@
   white-space: pre-wrap;
   overflow-x: none;
   overflow-y: scroll;
+  display: flex;
+  align-items: flex-end;
+  flex-direction:column;
+  justify-content:space-between;
 }
 .Console.open {
   height: 30%;

--- a/ui/src/css/console.css
+++ b/ui/src/css/console.css
@@ -5,10 +5,11 @@
   font-family: monospace;
   font-size: 11px;
   white-space: pre-wrap;
-  overflow-y: auto;
+  overflow-x: none;
+  overflow-y: scroll;
 }
 .Console.open {
-  height: 100px;
+  height: 30%;
 }
 
 .Console .console-output {


### PR DESCRIPTION
Attempting to fix #6 , but finding it difficult to have a console that can be resized and have an overflow-y scroll.

This PR removes the console resizing to get a base working console that does not have edge cases that don't work. Resizing can be added back in the future to avoid having the bug on master.
- [x] align textbox and text output to bottom