### PR TITLE
Remove kitchen sink example from dropdown

### DIFF
--- a/ui/src/components/Engine.jsx
+++ b/ui/src/components/Engine.jsx
@@ -288,10 +288,6 @@ class Engine extends React.Component {
                     <i class="fas fa-globe-europe"/>
                     <div className="label">WebXR Sample</div>
                   </div>
-                  <div className="menu-item-popup-item" onClick={() => this.addTemplate('kitchenSink')}>
-                    <i class="far fa-meteor"/>
-                    <div className="label">Kitchen sink</div>
-                  </div>
                   <div className="menu-item-popup-item" onClick={() => this.addTemplate('exobot')}>
                     <i class="fal fa-robot"/>
                     <div className="label">Exobot</div>


### PR DESCRIPTION
This PR removes the kitchen sink example from the dropdown per https://github.com/exokitxr/studio/issues/28#issuecomment-500280714.

Closes #28 