### PR TITLE
Studio Electron top level

### DIFF
--- a/index.html
+++ b/index.html
@@ -913,10 +913,6 @@ uiIframe.onload = () => {
         const {devicePixelRatio} = window;
 
         const sceneCanvas = renderer.domElement;
-        // sceneCanvas.setPosition(position[0], position[1]);
-        // sceneCanvas.left = position[0];
-        // sceneCanvas.top = position[1];
-        // viewport.fromArray(vp);
         sceneCanvas.setPosition(viewport[0], viewport[1]);
         sceneCanvas.setSize(viewport[2], viewport[3]);
 

--- a/index.html
+++ b/index.html
@@ -918,6 +918,56 @@ uiIframe.onload = () => {
 
         break;
       }
+      case 'viewportMouseDown': {
+        const {x, y, button} = m.data;
+        window.dispatchEvent(new MouseEvent('mousedown', {
+          clientX: x,
+          clientY: y,
+          button,
+        }));
+
+        break;
+      }
+      case 'viewportMouseUp': {
+        const {x, y, button} = m.data;
+        window.dispatchEvent(new MouseEvent('mouseup', {
+          clientX: x,
+          clientY: y,
+          button,
+        }));
+
+        break;
+      }
+      case 'viewportClick': {
+        const {x, y, button} = m.data;
+        window.dispatchEvent(new MouseEvent('click', {
+          clientX: x,
+          clientY: y,
+          button,
+        }));
+
+        break;
+      }
+      case 'viewportMouseMove': {
+        const {x, y} = m.data;
+        window.dispatchEvent(new MouseEvent('mousemove', {
+          clientX: x,
+          clientY: y,
+        }));
+
+        break;
+      }
+      case 'viewportMouseWheel': {
+        const {x, y, deltaX, deltaY} = m.data;
+        window.dispatchEvent(new MouseEvent('mousewheel', {
+          clientX: x,
+          clientY: y,
+          deltaX,
+          deltaY,
+        }));
+
+        break;
+      }
       case 'click': {
         const {target} = m.data;
         if (target === 'fakeXr') {

--- a/index.html
+++ b/index.html
@@ -1093,12 +1093,6 @@ uiIframe.onload = () => {
   `); */
 
   _bindEventTarget('ui');
-  /* window.addEventListener('resize', e => {
-    // renderer.setSize(window.innerWidth, window.innerHeight);
-
-    uiIframe.width = window.innerWidth;
-    uiIframe.height = window.innerHeight;
-  }); */
 
   _pushDomUpdate();
 };

--- a/index.html
+++ b/index.html
@@ -911,11 +911,23 @@ uiIframe.onload = () => {
     switch (m.data.method) {
       case 'viewport': {
         const {viewport} = m.data;
-        const {devicePixelRatio} = window;
+
+        // console.log('got viewport', viewport);
+
+        /* const sceneCanvas = renderer.domElement;
+        sceneCanvas.setPosition(viewport[0], viewport[1]);
+        sceneCanvas.setSize(viewport[2], viewport[3]); */
+
+        break;
+      }
+      case 'resize': {
+        const {x, y, width, height} = m.data;
+
+        // console.log('got resize', {x, y, width, height});
 
         const sceneCanvas = renderer.domElement;
-        sceneCanvas.setPosition(viewport[0], viewport[1]);
-        sceneCanvas.setSize(viewport[2], viewport[3]);
+        sceneCanvas.setPosition(x, y);
+        sceneCanvas.setSize(width, height);
 
         break;
       }

--- a/index.html
+++ b/index.html
@@ -1108,6 +1108,12 @@ window.addEventListener('resize', e => {
   uiIframe.width = window.innerWidth;
   uiIframe.height = window.innerHeight;
 });
+window.addEventListener('focus', e => {
+  uiIframe.setAlwaysOnTop(true);
+});
+window.addEventListener('blur', e => {
+  uiIframe.setAlwaysOnTop(false);
+});
 
 // events
 

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
     <script src="xrmp.js"></script>
     <script src="xrmp-three.js"></script>
     <script>
-let display, fakeXrDisplay, tabs = [], tabId = 0, xrmp, lastPresseds = [false, false], lastAxes = [[0.5, 0.5], [0.5, 0.5]], lastPadToucheds = [false, false], scrollFactors = [0, 0], scaleFactors = [1, 1], viewport = new THREE.Vector4(0, 0, 0, 0), menuOpen = false, orbitControls, transformControls;
+let display, fakeXrDisplay, tabs = [], tabId = 0, xrmp, lastPresseds = [false, false], lastAxes = [[0.5, 0.5], [0.5, 0.5]], lastPadToucheds = [false, false], scrollFactors = [0, 0], scaleFactors = [1, 1], viewport = new THREE.Vector4(0, 0, 1, 1), menuOpen = false, orbitControls, transformControls;
 
 const links = [
   {

--- a/index.html
+++ b/index.html
@@ -1167,9 +1167,6 @@ const _bindEventTarget = target => {
     };
 
     _bindEvents({
-      mousedown(e) {
-        uiIframe.sendMouseDown(e.clientX, e.clientY, e.button);
-      },
       mousemove(e) {
         const localCamera = camera;
         localCamera.matrixWorldInverse.fromArray(fakeXrDisplay.viewMatrix);
@@ -1221,33 +1218,16 @@ const _bindEventTarget = target => {
           _removeTransformControls();
         }
       },
-      mouseup(e) {
-        if (!orbitControls) {
-          uiIframe.sendMouseUp(e.clientX, e.clientY, e.button);
-        }
-      },
-      wheel(e) {
-        if (!orbitControls) {
-          uiIframe.sendMouseWheel(e.clientX, e.clientY, e.deltaX, -e.deltaY);
-        }
-      },
       keydown(e) {
         if (e.keyCode === 37 && e.altKey) { // Alt-Left
           uiIframe.back();
         } else if (e.keyCode === 39 && e.altKey) { // Alt-Right
           uiIframe.forward();
-        } else {
-          uiIframe.sendKeyDown(e.keyCode,{shiftKey:e.shiftKey,ctrlKey:e.ctrlKey,altKey:e.altKey});
         }
-      },
-      keyup(e) {
-        uiIframe.sendKeyUp(e.keyCode,{shiftKey:e.shiftKey,ctrlKey:e.ctrlKey,altKey:e.altKey});
       },
       keypress(e) {
         if (e.keyCode === 114 && e.ctrlKey) { // Ctrl-R
           uiIframe.reload();
-        } else {
-          uiIframe.sendKeyPress(e.keyCode,{shiftKey:e.shiftKey,ctrlKey:e.ctrlKey,altKey:e.altKey});
         }
       },
     });

--- a/index.html
+++ b/index.html
@@ -886,43 +886,6 @@ scene.add(directionalLight);
 
 // iframe
 
-const composeVsh = `#version 300 es
-  in vec2 position;
-  in vec2 uv;
-  out vec2 vUv;
-  void main() {
-    gl_Position = vec4(position.xy, 0., 1.);
-    vUv = uv;
-  }
-`;
-const composeFsh = `#version 300 es
-  uniform vec4 viewport;
-  uniform sampler2D uiTex;
-  uniform sampler2D viewportTex;
-  in vec2 vUv;
-  out vec4 fragColor;
-  void main() {
-    vec4 uiSample = texture2D(uiTex, vec2(vUv.x, 1.0-vUv.y));
-    vec4 viewportOffset = vec4(viewport.x, 1.0-viewport.y-viewport.w, viewport.x + viewport.z, 1.0-viewport.y);
-    if (vUv.x >= viewportOffset.x && vUv.y >= viewportOffset.y && vUv.x < viewportOffset.z && vUv.y < viewportOffset.w) {
-      if (uiSample.r == 0.0 && uiSample.g == 1.0 && uiSample.b == 0.0 && uiSample.a == 1.0) {
-        vec4 viewportSample = texture2D(
-          viewportTex,
-          vec2(
-            (vUv.x - viewportOffset.x) / (viewportOffset.z - viewportOffset.x),
-            (vUv.y - viewportOffset.y) / (viewportOffset.w - viewportOffset.y)
-          )
-        );
-        fragColor = viewportSample;
-      } else {
-        fragColor = uiSample;
-      }
-    } else {
-      fragColor = uiSample;
-    }
-  }
-`;
-
 const _pushDomUpdate = () => {
   if (uiIframe.contentWindow) {
     browser.requestDomExport(document.body.parentNode)
@@ -934,257 +897,151 @@ const _pushDomUpdate = () => {
       });
   }
 };
-const {
-  canvas: composeCanvas,
-  gl: composeContext,
-  iframe: uiIframe,
-} = (() => {
-  const canvas = document.createElement('canvas');
-  canvas.width = window.innerWidth;
-  canvas.height = window.innerHeight;
-  const gl = canvas.getContext('webgl', {
-    desynchronized: true,
-  });
 
-  const vao = gl.createVertexArray();
-  gl.bindVertexArray(vao);
+const uiIframe = document.createElement('iframe');
+uiIframe.width = window.innerWidth;
+uiIframe.height = window.innerHeight;
+uiIframe.devicePixelRatio = window.devicePixelRatio;
+uiIframe.d = 2;
+uiIframe.inline = false;
+uiIframe.src = 'ui/build/index.html';
+uiIframe.onload = () => {
+  uiIframe.contentWindow.onmessage = m => {
+    switch (m.data.method) {
+      case 'viewport': {
+        const {viewport} = m.data;
+        const {devicePixelRatio} = window;
 
-  // vertex shader
-  const composeVertex = gl.createShader(gl.VERTEX_SHADER);
-  gl.shaderSource(composeVertex, composeVsh);
-  gl.compileShader(composeVertex);
-  let success = gl.getShaderParameter(composeVertex, gl.COMPILE_STATUS);
-  if (!success) {
-    console.log('compose vertex shader compilation failed:\n' + gl.getShaderInfoLog(composeVertex) + '\n' + gl.getShaderSource(composeVertex).split('\n').map((l, i) => `${i+1}: ${l}`).join('\n'));
-    // return;
-  };
+        const sceneCanvas = renderer.domElement;
+        // sceneCanvas.setPosition(position[0], position[1]);
+        // sceneCanvas.left = position[0];
+        // sceneCanvas.top = position[1];
+        // viewport.fromArray(vp);
+        sceneCanvas.setPosition(viewport[0], viewport[1]);
+        sceneCanvas.setSize(viewport[2], viewport[3]);
 
-  // fragment shader
-  const composeFragment = gl.createShader(gl.FRAGMENT_SHADER);
-  gl.shaderSource(composeFragment, composeFsh);
-  gl.compileShader(composeFragment);
-  success = gl.getShaderParameter(composeFragment, gl.COMPILE_STATUS);
-  if (!success) {
-    const infoLog = gl.getShaderInfoLog(composeFragment);
-    console.log('compose fragment shader compilation failed:\n' + gl.getShaderInfoLog(composeFragment) + '\n' + gl.getShaderSource(composeFragment).split('\n').map((l, i) => `${i+1}: ${l}`).join('\n'));
-    // return;
-  };
-
-  // shader program
-  gl.composeProgram = gl.createProgram();
-  gl.attachShader(gl.composeProgram, composeVertex);
-  gl.attachShader(gl.composeProgram, composeFragment);
-  gl.linkProgram(gl.composeProgram);
-  success = gl.getProgramParameter(gl.composeProgram, gl.LINK_STATUS);
-  if (!success) {
-    const infoLog = gl.getProgramInfoLog(gl.composeProgram);
-    console.log('compose program linking failed:', infoLog);
-    // return;
-  }
-
-  gl.positionLocation = gl.getAttribLocation(gl.composeProgram, "position");
-  if (gl.positionLocation == -1) {
-    console.log('compose program failed to get attrib location for "position"');
-    // return;
-  }
-  gl.uvLocation = gl.getAttribLocation(gl.composeProgram, "uv");
-  if (gl.uvLocation === -1) {
-    console.log('compose program failed to get attrib location for "uv"');
-    // return;
-  }
-  gl.viewportLocation = gl.getUniformLocation(gl.composeProgram, "viewport");
-  if (gl.viewportLocation === -1) {
-    console.log('compose program failed to get attrib location for "viewport"');
-    // return;
-  }
-  gl.uiTexLocation = gl.getUniformLocation(gl.composeProgram, "uiTex");
-  if (gl.uiTexLocation === -1) {
-    console.log('compose program failed to get attrib location for "uiTex"');
-    // return;
-  }
-  gl.viewportTexLocation = gl.getUniformLocation(gl.composeProgram, "viewportTex");
-  if (gl.viewportTexLocation === -1) {
-    console.log('compose program failed to get attrib location for "viewportTex"');
-    // return;
-  }
-
-  // delete the shaders as they're linked into our program now and no longer necessary
-  gl.deleteShader(composeVertex);
-  gl.deleteShader(composeFragment);
-
-  const positionBuffer = gl.createBuffer();
-  gl.bindBuffer(gl.ARRAY_BUFFER, positionBuffer);
-  const positions = Float32Array.from([
-    -1.0, 1.0,
-    1.0, 1.0,
-    -1.0, -1.0,
-    1.0, -1.0,
-  ]);
-  gl.bufferData(gl.ARRAY_BUFFER, positions, gl.STATIC_DRAW);
-  gl.enableVertexAttribArray(gl.positionLocation);
-  gl.vertexAttribPointer(gl.positionLocation, 2, gl.FLOAT, false, 0, 0);
-
-  const uvBuffer = gl.createBuffer();
-  gl.bindBuffer(gl.ARRAY_BUFFER, uvBuffer);
-  const uvs = Float32Array.from([
-    0.0, 1.0,
-    1.0, 1.0,
-    0.0, 0.0,
-    1.0, 0.0,
-  ]);
-  gl.bufferData(gl.ARRAY_BUFFER, uvs, gl.STATIC_DRAW);
-  gl.enableVertexAttribArray(gl.uvLocation);
-  gl.vertexAttribPointer(gl.uvLocation, 2, gl.FLOAT, false, 0, 0);
-
-  const indexBuffer = gl.createBuffer();
-  const indices = Uint16Array.from([0, 2, 1, 2, 3, 1]);
-  gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, indexBuffer);
-  gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, indices, gl.STATIC_DRAW);
-
-  document.body.appendChild(canvas);
-
-  const iframe = document.createElement('iframe');
-  iframe.width = window.innerWidth;
-  iframe.height = window.innerHeight;
-  iframe.devicePixelRatio = window.devicePixelRatio;
-  iframe.d = 2;
-  iframe.src = 'ui/build/index.html';
-  iframe.onload = () => {
-    iframe.contentWindow.onmessage = m => {
-      switch (m.data.method) {
-        case 'viewport': {
-          viewport.set(m.data.viewport[0], m.data.viewport[1], m.data.viewport[2], m.data.viewport[3]);
-          break;
-        }
-        case 'click': {
-          const {target} = m.data;
-          if (target === 'fakeXr') {
-            renderer.domElement.requestPointerLock();
-            _bindEventTarget('xr');
-          } else if (target === 'xr') {
-            console.log('xr click');
-          } else if (target === 'transform') {
-            console.log('transform click');
-          }
-          break;
-        }
-        case 'menu': {
-          menuOpen = m.data.open;
-          /* if (m.data.open) {
-            composeScene.remove(composeScreenQuad); // XXX can elide the render entirely
-          } else {
-            composeScene.add(composeScreenQuad);
-          } */
-          break;
-        }
-        case 'open': {
-          const {url, d} = m.data;
-          const {position, quaternion, scale} = _getFrontOfCamera();
-          _openUrl(url, position, quaternion, scale, d);
-
-          break;
-        }
-        case 'add': {
-          const {template} = m.data;
-          const url = links.find(link => link.id === template).url;
-          const {position, quaternion, scale} = _getFrontOfCamera();
-          _openUrl(url, position, quaternion, scale, 3);
-
-          break;
-        }
-        case 'eval': {
-          let err, result;
-          try {
-            result = eval(m.data.jsString);
-          } catch(e) {
-            err = e;
-          }
-          if (!err) {
-            iframe.contentWindow.postMessage({
-              method: 'terminal',
-              output: browser.inspect(result),
-            });
-          } else {
-            iframe.contentWindow.postMessage({
-              method: 'terminal',
-              output: err.stack,
-            });
-          }
-          break;
-        }
-        case 'edit': {
-          browser.applyDomEdit(document.body.parentNode, m.data.keypath, m.data.edit)
-            .then(() => {
-              _pushDomUpdate();
-            })
-            .catch(err => {
-              console.warn(err.stack);
-            });
-          break;
-        }
-        case 'setting': {
-          const {key, value} = m.data;
-          window.browser.setSetting(key, value);
-          break;
-        }
-        case 'fakeVrMetrics': {
-          const {width, height} = m.data;
-          _endFakeVrDisplay()
-            .then(() => _startFakeVrDisplay(width, height))
-            .catch(err => {
-              console.warn(err.stack);
-            });
-          break;
-        }
-        default: {
-          console.warn(`got unknown ui iframe message: ${m.data.method}`);
-          break;
-        }
+        break;
       }
-      /* switch (m.data.action){
-        case 'launch':
-          launch(m.data.flags, m.data.url);
-          break;
-        case 'update':
-          update();
-          break;
-      } */
+      case 'click': {
+        const {target} = m.data;
+        if (target === 'fakeXr') {
+          renderer.domElement.requestPointerLock();
+          _bindEventTarget('xr');
+        } else if (target === 'xr') {
+          console.log('xr click');
+        } else if (target === 'transform') {
+          console.log('transform click');
+        }
+        break;
+      }
+      case 'menu': {
+        menuOpen = m.data.open;
+        /* if (m.data.open) {
+          composeScene.remove(composeScreenQuad); // XXX can elide the render entirely
+        } else {
+          composeScene.add(composeScreenQuad);
+        } */
+        break;
+      }
+      case 'open': {
+        const {url, d} = m.data;
+        const {position, quaternion, scale} = _getFrontOfCamera();
+        _openUrl(url, position, quaternion, scale, d);
+
+        break;
+      }
+      case 'add': {
+        const {template} = m.data;
+        const url = links.find(link => link.id === template).url;
+        const {position, quaternion, scale} = _getFrontOfCamera();
+        _openUrl(url, position, quaternion, scale, 3);
+
+        break;
+      }
+      case 'eval': {
+        let err, result;
+        try {
+          result = eval(m.data.jsString);
+        } catch(e) {
+          err = e;
+        }
+        if (!err) {
+          uiIframe.contentWindow.postMessage({
+            method: 'terminal',
+            output: browser.inspect(result),
+          });
+        } else {
+          uiIframe.contentWindow.postMessage({
+            method: 'terminal',
+            output: err.stack,
+          });
+        }
+        break;
+      }
+      case 'edit': {
+        browser.applyDomEdit(document.body.parentNode, m.data.keypath, m.data.edit)
+          .then(() => {
+            _pushDomUpdate();
+          })
+          .catch(err => {
+            console.warn(err.stack);
+          });
+        break;
+      }
+      case 'setting': {
+        const {key, value} = m.data;
+        window.browser.setSetting(key, value);
+        break;
+      }
+      case 'fakeVrMetrics': {
+        const {width, height} = m.data;
+        _endFakeVrDisplay()
+          .then(() => _startFakeVrDisplay(width, height))
+          .catch(err => {
+            console.warn(err.stack);
+          });
+        break;
+      }
+      default: {
+        console.warn(`got unknown ui iframe message: ${m.data.method}`);
+        break;
+      }
+    }
+    /* switch (m.data.action){
+      case 'launch':
+        launch(m.data.flags, m.data.url);
+        break;
+      case 'update':
+        update();
+        break;
+    } */
+  };
+
+  /* uiIframe.runJs(`
+    // document.body.style.background = '#000080';
+    // console.log('run js log ' + typeof window.postMessage + ' ' + window.postMessage.toString());
+
+    window.onmessage = m => {
+      console.log('child got message: ' + JSON.stringify(m.data));
     };
 
-    /* iframe.runJs(`
-      // document.body.style.background = '#000080';
-      // console.log('run js log ' + typeof window.postMessage + ' ' + window.postMessage.toString());
+    window.postMessage({lol: 'zol'});
+  `); */
 
-      window.onmessage = m => {
-        console.log('child got message: ' + JSON.stringify(m.data));
-      };
+  _bindEventTarget('ui');
+  window.addEventListener('resize', e => {
+    // renderer.setSize(window.innerWidth, window.innerHeight);
 
-      window.postMessage({lol: 'zol'});
-    `); */
+    uiIframe.width = window.innerWidth;
+    uiIframe.height = window.innerHeight;
+  });
 
-    _bindEventTarget('ui');
-    window.addEventListener('resize', e => {
-      // renderer.setSize(window.innerWidth, window.innerHeight);
-
-      composeCanvas.width = window.innerWidth;
-      composeCanvas.height = window.innerHeight;
-      uiIframe.width = window.innerWidth;
-      uiIframe.height = window.innerHeight;
-    });
-
-    _pushDomUpdate();
-  };
-  iframe.onconsole = (message, source, line) => {
-    console.log(source + ':' + line + ': ' + message);
-  };
-  document.body.appendChild(iframe);
-
-  return {
-    canvas,
-    gl,
-    iframe,
-  };
-})();
+  _pushDomUpdate();
+};
+uiIframe.onconsole = (message, source, line) => {
+  console.log(source + ':' + line + ': ' + message);
+};
+document.body.appendChild(uiIframe);
 
 // events
 
@@ -1217,136 +1074,105 @@ const _bindEventTarget = target => {
     };
   };
   if (target === 'ui') {
+    const _addOrbitControls = () => {
+      const orbitCamera = new THREE.PerspectiveCamera(60, window.innerWidth / window.innerHeight, 1, 1000);
+      orbitControls = new THREE.OrbitControls(orbitCamera);
+      orbitCamera.position.copy(fakeXrDisplay.position);
+      orbitCamera.quaternion.copy(fakeXrDisplay.quaternion);
+      scene.add(orbitCamera);
+      orbitCamera.updateMatrixWorld();
+      orbitControls.target.copy(orbitCamera.position).add(new THREE.Vector3(0, 0, -1).applyQuaternion(orbitCamera.quaternion));
+      orbitControls.screenSpacePanning = true;
+      orbitControls.update();
+    };
+    const _removeOrbitControls = () => {
+      scene.remove(orbitControls.object);
+      orbitControls.dispose();
+      orbitControls = null;
+    };
+    const _addTransformControls = (camera, iframe) => {
+      transformControls = new THREE.TransformControls(camera, document.body, viewport);
+      transformControls.iframe = iframe;
+
+      transformControls.addEventListener('dragging-changed', e => {
+        orbitControls.enabled = !e.value;
+      });
+      transformControls.addEventListener('change', e => {
+        iframe.position = mesh.position.toArray();
+        iframe.orientation = mesh.quaternion.toArray();
+        iframe.scale = mesh.scale.toArray();
+      });
+
+      const mesh = new THREE.Object3D();
+      mesh.position.fromArray(_parseVector(iframe.position));
+      mesh.quaternion.fromArray(_parseVector(iframe.orientation));
+      mesh.scale.fromArray(_parseVector(iframe.scale));
+      scene.add(mesh);
+      mesh.updateMatrixWorld();
+
+      transformControls.attach(mesh);
+      scene.add(transformControls);
+    };
+    const _removeTransformControls = () => {
+      scene.remove(transformControls.object);
+      scene.remove(transformControls);
+      transformControls.dispose();
+      transformControls = null;
+    };
+
     _bindEvents({
       mousedown(e) {
-        if (!orbitControls) {
-          uiIframe.sendMouseDown(e.clientX, e.clientY, e.button);
-        }
+        uiIframe.sendMouseDown(e.clientX, e.clientY, e.button);
       },
       mousemove(e) {
-        const _addOrbitControls = () => {
-          const orbitCamera = new THREE.PerspectiveCamera(60, window.innerWidth / window.innerHeight, 1, 1000);
-          orbitControls = new THREE.OrbitControls(orbitCamera);
-          orbitCamera.position.copy(fakeXrDisplay.position);
-          orbitCamera.quaternion.copy(fakeXrDisplay.quaternion);
-          scene.add(orbitCamera);
-          orbitCamera.updateMatrixWorld();
-          orbitControls.target.copy(orbitCamera.position).add(new THREE.Vector3(0, 0, -1).applyQuaternion(orbitCamera.quaternion));
-          orbitControls.screenSpacePanning = true;
-          orbitControls.update();
-        };
-        const _removeOrbitControls = () => {
-          scene.remove(orbitControls.object);
-          orbitControls.dispose();
-          orbitControls = null;
-        };
-        const _addTransformControls = (camera, iframe) => {
-          transformControls = new THREE.TransformControls(camera, document.body, viewport);
-          transformControls.iframe = iframe;
+        const localCamera = camera;
+        localCamera.matrixWorldInverse.fromArray(fakeXrDisplay.viewMatrix);
+        localCamera.matrixWorld.getInverse(localCamera.matrixWorldInverse);
+        localCamera.projectionMatrix.fromArray(fakeXrDisplay.projectionMatrix);
+        localCamera.projectionMatrixInverse.getInverse(localCamera.projectionMatrix);
 
-          transformControls.addEventListener('dragging-changed', e => {
-            orbitControls.enabled = !e.value;
-          });
-          transformControls.addEventListener('change', e => {
-            iframe.position = mesh.position.toArray();
-            iframe.orientation = mesh.quaternion.toArray();
-            iframe.scale = mesh.scale.toArray();
-          });
-
-          const mesh = new THREE.Object3D();
-          mesh.position.fromArray(_parseVector(iframe.position));
-          mesh.quaternion.fromArray(_parseVector(iframe.orientation));
-          mesh.scale.fromArray(_parseVector(iframe.scale));
-          scene.add(mesh);
-          mesh.updateMatrixWorld();
-
-          transformControls.attach(mesh);
-          scene.add(transformControls);
-        };
-        const _removeTransformControls = () => {
-          scene.remove(transformControls.object);
-          scene.remove(transformControls);
-          transformControls.dispose();
-          transformControls = null;
-        };
-
-        const x = e.clientX/window.innerWidth;
-        const y = e.clientY/window.innerHeight;
-        const minX = viewport.x;
-        const minY = viewport.y;
-        const maxX = viewport.x + viewport.z;
-        const maxY = viewport.y + viewport.w;
-        const shouldOrbit = x >= minX && x < maxX && y >= minY && y < maxY && !menuOpen;
-        if (shouldOrbit && !orbitControls) {
-          _addOrbitControls();
-        } else if (!shouldOrbit && orbitControls) {
-          _removeOrbitControls();
-        }
-
-        if (orbitControls) {
-          const localCamera = camera;
-          localCamera.matrixWorldInverse.fromArray(fakeXrDisplay.viewMatrix);
-          localCamera.matrixWorld.getInverse(localCamera.matrixWorldInverse);
-          localCamera.projectionMatrix.fromArray(fakeXrDisplay.projectionMatrix);
-          localCamera.projectionMatrixInverse.getInverse(localCamera.projectionMatrix);
-
-          const rect = document.body.getBoundingClientRect();
-          rect.left += viewport.x*rect.width;
-          rect.top += viewport.y*rect.height;
-          rect.width *= viewport.z;
-          rect.height *= viewport.w;
-
-          localCamera.matrixWorld.decompose(localCamera.position, localCamera.quaternion, localCamera.scale);
-          localRaycaster.setFromCamera(
-            localVector2D.set(
-              (((e.clientX - rect.left) / rect.width) % 0.5 * 2) * 2 - 1,
-              (-(e.clientY - rect.top) / rect.height) * 2 + 1
-            ),
-            localCamera
-          );
-          const line = localLine.set(
-            localRaycaster.ray.origin,
-            localVector.copy(localRaycaster.ray.origin)
-              .add(localVector2.copy(localRaycaster.ray.direction).multiplyScalar(100))
-          );
-          /* cubeMesh.position.copy(localRaycaster.ray.origin)
-            .add(localVector2.copy(localRaycaster.ray.direction).multiplyScalar(5));
-          cubeMesh.updateMatrixWorld(); */
-          const distanceSpecs = layers.map(layer => {
-            if (layer.tagName === 'IFRAME') {
-              line.closestPointToPoint(localVector.fromArray(_parseVector(layer.position)), true, localVector2);
-              const distance = localVector.distanceTo(localVector2);
-              if (distance < 1) {
-                return {
-                  iframe: layer,
-                  distance,
-                };
-              } else {
-                return null;
-              }
+        localCamera.matrixWorld.decompose(localCamera.position, localCamera.quaternion, localCamera.scale);
+        localRaycaster.setFromCamera(
+          localVector2D.set(
+            ((e.clientX / renderer.domElement.width) % 0.5 * 2) * 2 - 1,
+            (-e.clientY / renderer.domElement.height) * 2 + 1
+          ),
+          localCamera
+        );
+        const line = localLine.set(
+          localRaycaster.ray.origin,
+          localVector.copy(localRaycaster.ray.origin)
+            .add(localVector2.copy(localRaycaster.ray.direction).multiplyScalar(100))
+        );
+        /* cubeMesh.position.copy(localRaycaster.ray.origin)
+          .add(localVector2.copy(localRaycaster.ray.direction).multiplyScalar(5));
+        cubeMesh.updateMatrixWorld(); */
+        const distanceSpecs = layers.map(layer => {
+          if (layer.tagName === 'IFRAME') {
+            line.closestPointToPoint(localVector.fromArray(_parseVector(layer.position)), true, localVector2);
+            const distance = localVector.distanceTo(localVector2);
+            if (distance < 1) {
+              return {
+                iframe: layer,
+                distance,
+              };
             } else {
               return null;
             }
-          }).filter(spec => !!spec).sort((a, b) => a.distance - b.distance);
-          const closestIframe = distanceSpecs.length > 0 ? distanceSpecs[0].iframe : null;
-          const shouldTransform = (!!transformControls && transformControls.dragging) || !!closestIframe;
-          if (shouldTransform && (!transformControls || (transformControls.iframe !== closestIframe && !transformControls.dragging))) {
-            if (transformControls) {
-              _removeTransformControls();
-            }
-
-            _addTransformControls(localCamera, closestIframe);
-          } else if (!shouldTransform && transformControls) {
-            _removeTransformControls();
+          } else {
+            return null;
           }
-        } else {
+        }).filter(spec => !!spec).sort((a, b) => a.distance - b.distance);
+        const closestIframe = distanceSpecs.length > 0 ? distanceSpecs[0].iframe : null;
+        const shouldTransform = (!!transformControls && transformControls.dragging) || !!closestIframe;
+        if (shouldTransform && (!transformControls || (transformControls.iframe !== closestIframe && !transformControls.dragging))) {
           if (transformControls) {
             _removeTransformControls();
           }
-        }
 
-        if (!orbitControls) {
-          uiIframe.sendMouseMove(e.clientX, e.clientY);
+          _addTransformControls(localCamera, closestIframe);
+        } else if (!shouldTransform && transformControls) {
+          _removeTransformControls();
         }
       },
       mouseup(e) {
@@ -1379,6 +1205,12 @@ const _bindEventTarget = target => {
         }
       },
     });
+
+    _addOrbitControls();
+    unbindEvents = (unbindEvents => function() {
+      unbindEvents.apply(this, arguments);
+      _removeOrbitControls();
+    })();
   } else if (target === 'xr') {
     _bindEvents({
       /* click(e) {
@@ -2453,7 +2285,7 @@ const intersectionSpecs = [
 // let renderTarget = null;
 const startTime = Date.now();
 let lastTime = 0;
-function animateXrScene(time, frame) {
+function animate(time, frame) {
   /* const gl = renderer.getContext();
   gl.clearColor(1, 0, 0, 1);
   gl.clear(gl.COLOR_BUFFER_BIT|gl.DEPTH_BUFFER_BIT|gl.STENCIL_BUFFER_BIT);
@@ -3275,30 +3107,6 @@ function animateXrScene(time, frame) {
   _updateMp();
 
   lastTime = now;
-}
-function animateComposeContext(time, frame) {
-  const gl = composeContext;
-
-  gl.bindFramebuffer(gl.FRAMEBUFFER, 0);
-
-  gl.useProgram(gl.composeProgram);
-
-  gl.activeTexture(gl.TEXTURE0);
-  gl.bindTexture(gl.TEXTURE_2D, uiIframe.texture);
-  gl.uniform1i(gl.uiTexLocation, 0);
-
-  gl.activeTexture(gl.TEXTURE1);
-  gl.bindTexture(gl.TEXTURE_2D, fakeXrDisplay.texture);
-  gl.uniform1i(gl.viewportTexLocation, 1);
-
-  gl.uniform4f(gl.viewportLocation, viewport.x, viewport.y, viewport.z, viewport.w);
-
-  gl.viewport(0, 0, composeCanvas.width, composeCanvas.height);
-  gl.drawElements(gl.TRIANGLES, 6, gl.UNSIGNED_SHORT, 0);
-}
-function animate(time, frame) {
-  animateXrScene(time, frame);
-  animateComposeContext(time, frame);
 }
 
 // bootstrap

--- a/index.html
+++ b/index.html
@@ -919,13 +919,10 @@ uiIframe.onload = () => {
   uiIframe.contentWindow.onmessage = m => {
     switch (m.data.method) {
       case 'viewport': {
-        const {viewport} = m.data;
+        const {viewport: vp} = m.data;
 
-        console.log('got viewport', viewport);
-
-        /* const sceneCanvas = renderer.domElement;
-        sceneCanvas.setPosition(viewport[0], viewport[1]);
-        sceneCanvas.setSize(viewport[2], viewport[3]); */
+        // console.log('got viewport', vp);
+        // viewport.fromArray(vp);
 
         break;
       }
@@ -1195,10 +1192,13 @@ const _bindEventTarget = target => {
         localCamera.projectionMatrixInverse.getInverse(localCamera.projectionMatrix);
 
         localCamera.matrixWorld.decompose(localCamera.position, localCamera.quaternion, localCamera.scale);
+        const rect = document.body.getBoundingClientRect();
         localRaycaster.setFromCamera(
           localVector2D.set(
-            ((e.clientX / renderer.domElement.width) % 0.5 * 2) * 2 - 1,
-            (-e.clientY / renderer.domElement.height) * 2 + 1
+            ((e.clientX / rect.width) % 0.5 * 2) * 2 - 1,
+            (-e.clientY / rect.height) * 2 + 1
+            /* ((e.clientX / rect.width * viewport.z - viewport.x) % 0.5 * 2) * 2 - 1,
+            (-e.clientY / rect.height * viewport.w - viewport.y) * 2 + 1 */
           ),
           localCamera
         );

--- a/index.html
+++ b/index.html
@@ -980,7 +980,16 @@ uiIframe.onload = () => {
         const {target} = m.data;
         if (target === 'fakeXr') {
           renderer.domElement.requestPointerLock();
-          renderer.domElement.setFocus();
+          for (let i = 0; i < 1000; i += 100) {
+            if (i > 0) {
+              setTimeout(() => {
+                renderer.domElement.setFocus();
+              }, i);
+            } else {
+              renderer.domElement.setFocus();
+            }
+          }
+
           _bindEventTarget('xr');
         } else if (target === 'xr') {
           console.log('xr click');

--- a/index.html
+++ b/index.html
@@ -907,27 +907,25 @@ uiIframe.d = 2;
 uiIframe.inline = false;
 uiIframe.src = 'ui/build/index.html';
 uiIframe.onload = () => {
+  uiIframe.contentWindow.addEventListener('resize', e => {
+    const {x, y, width, height} = e;
+
+    // console.log('got resize', {x, y, width, height});
+
+    const sceneCanvas = renderer.domElement;
+    sceneCanvas.setPosition(x, y);
+    sceneCanvas.setSize(width, height);
+  });
   uiIframe.contentWindow.onmessage = m => {
     switch (m.data.method) {
       case 'viewport': {
         const {viewport} = m.data;
 
-        // console.log('got viewport', viewport);
+        console.log('got viewport', viewport);
 
         /* const sceneCanvas = renderer.domElement;
         sceneCanvas.setPosition(viewport[0], viewport[1]);
         sceneCanvas.setSize(viewport[2], viewport[3]); */
-
-        break;
-      }
-      case 'resize': {
-        const {x, y, width, height} = m.data;
-
-        // console.log('got resize', {x, y, width, height});
-
-        const sceneCanvas = renderer.domElement;
-        sceneCanvas.setPosition(x, y);
-        sceneCanvas.setSize(width, height);
 
         break;
       }

--- a/index.html
+++ b/index.html
@@ -1114,6 +1114,12 @@ window.addEventListener('focus', e => {
 window.addEventListener('blur', e => {
   uiIframe.setAlwaysOnTop(false);
 });
+window.addEventListener('restore', e => {
+  uiIframe.show();
+});
+window.addEventListener('minimize', e => {
+  uiIframe.hide();
+});
 
 // events
 

--- a/index.html
+++ b/index.html
@@ -1100,6 +1100,14 @@ uiIframe.onconsole = (message, source, line) => {
   console.log(source + ':' + line + ': ' + message);
 };
 document.body.appendChild(uiIframe);
+window.addEventListener('move', e => {
+  const {x, y} = e.detail;
+  uiIframe.setPosition(x, y);
+});
+window.addEventListener('resize', e => {
+  uiIframe.width = window.innerWidth;
+  uiIframe.height = window.innerHeight;
+});
 
 // events
 

--- a/index.html
+++ b/index.html
@@ -874,6 +874,7 @@ const renderer = new THREE.WebGLRenderer({
   antialias: true,
 });
 // renderer.setSize(window.innerWidth, window.innerHeight);
+document.body.appendChild(renderer.domElement);
 
 const layers = [renderer.domElement];
 

--- a/index.html
+++ b/index.html
@@ -929,7 +929,7 @@ uiIframe.onload = () => {
 
         break;
       }
-      case 'viewportMouseDown': {
+      /* case 'viewportMouseDown': {
         const {x, y, button} = m.data;
         window.dispatchEvent(new MouseEvent('mousedown', {
           clientX: x,
@@ -978,7 +978,7 @@ uiIframe.onload = () => {
         }));
 
         break;
-      }
+      } */
       case 'click': {
         const {target} = m.data;
         if (target === 'fakeXr') {

--- a/index.html
+++ b/index.html
@@ -1076,12 +1076,12 @@ uiIframe.onload = () => {
   `); */
 
   _bindEventTarget('ui');
-  window.addEventListener('resize', e => {
+  /* window.addEventListener('resize', e => {
     // renderer.setSize(window.innerWidth, window.innerHeight);
 
     uiIframe.width = window.innerWidth;
     uiIframe.height = window.innerHeight;
-  });
+  }); */
 
   _pushDomUpdate();
 };

--- a/index.html
+++ b/index.html
@@ -983,6 +983,7 @@ uiIframe.onload = () => {
         const {target} = m.data;
         if (target === 'fakeXr') {
           renderer.domElement.requestPointerLock();
+          renderer.domElement.setFocus();
           _bindEventTarget('xr');
         } else if (target === 'xr') {
           console.log('xr click');

--- a/index.html
+++ b/index.html
@@ -1237,7 +1237,7 @@ const _bindEventTarget = target => {
     unbindEvents = (unbindEvents => function() {
       unbindEvents.apply(this, arguments);
       _removeOrbitControls();
-    })();
+    })(unbindEvents);
   } else if (target === 'xr') {
     for (let i = 0; i < 2; i++) {
       controllerMeshes[i].rayMesh.visible = true;

--- a/ui/src/components/Engine.jsx
+++ b/ui/src/components/Engine.jsx
@@ -358,7 +358,7 @@ class Engine extends React.Component {
   }
 
 class EngineRender extends React.Component {
-  onMouseDown(e) {
+  /* onMouseDown(e) {
     const engineRender = document.getElementById('engine-render');
     const bcr = engineRender.getBoundingClientRect();
     window.postMessage({
@@ -407,11 +407,12 @@ class EngineRender extends React.Component {
       deltaX: e.deltaX,
       deltaY: e.deltaY,
     });
-  }
+  } */
 
   render() {
+    /*<div className="engine-render" id="engine-render" onClick={e => this.onClick(e)} onMouseDown={e => this.onMouseDown(e)} onMouseUp={e => this.onMouseUp(e)} onMouseMove={e => this.onMouseMove(e)} onMouseWheel={e => this.onMouseWheel(e)} />*/
     return (
-      <div className="engine-render" id="engine-render" onClick={e => this.onClick(e)} onMouseDown={e => this.onMouseDown(e)} onMouseUp={e => this.onMouseUp(e)} onMouseMove={e => this.onMouseMove(e)} onMouseWheel={e => this.onMouseWheel(e)} />
+      <div className="engine-render" id="engine-render" />
     );
   }
 }

--- a/ui/src/components/Engine.jsx
+++ b/ui/src/components/Engine.jsx
@@ -36,6 +36,7 @@ class Engine extends React.Component {
     componentDidMount() {
       _postViewportMessage();
       window.addEventListener('resize', _postViewportMessage);
+      window.addEventListener('move', _postViewportMessage);
 
       /* window.addEventListener('keydown', e => {
         console.log('iframe keydown ' + e.keyCode);

--- a/ui/src/components/Engine.jsx
+++ b/ui/src/components/Engine.jsx
@@ -8,9 +8,9 @@ const _postViewportMessage = () => {
   const engineRender = document.getElementById('engine-render');
   const bcr = engineRender.getBoundingClientRect();
   // const position = [window.screenX + bcr.x, window.screenY + bcr.y];
-  // const viewport = [bcr.x/window.innerWidth, bcr.y/window.innerHeight, bcr.width/window.innerWidth, bcr.height/window.innerHeight];
+  const viewport = [bcr.x/window.innerWidth, bcr.y/window.innerHeight, bcr.width/window.innerWidth, bcr.height/window.innerHeight];
   // const viewport = [window.screenX + bcr.x, window.screenY + bcr.y, bcr.width, bcr.height];
-  const viewport = [bcr.x, bcr.y, bcr.width, bcr.height];
+  // const viewport = [bcr.x, bcr.y, bcr.width, bcr.height];
   window.postMessage({
     method: 'viewport',
     viewport,

--- a/ui/src/components/Engine.jsx
+++ b/ui/src/components/Engine.jsx
@@ -7,10 +7,7 @@ import '../css/engine.css';
 const _postViewportMessage = () => {
   const engineRender = document.getElementById('engine-render');
   const bcr = engineRender.getBoundingClientRect();
-  // const position = [window.screenX + bcr.x, window.screenY + bcr.y];
   const viewport = [bcr.x/window.innerWidth, bcr.y/window.innerHeight, bcr.width/window.innerWidth, bcr.height/window.innerHeight];
-  // const viewport = [window.screenX + bcr.x, window.screenY + bcr.y, bcr.width, bcr.height];
-  // const viewport = [bcr.x, bcr.y, bcr.width, bcr.height];
   window.postMessage({
     method: 'viewport',
     viewport,

--- a/ui/src/components/Engine.jsx
+++ b/ui/src/components/Engine.jsx
@@ -370,7 +370,7 @@ class Engine extends React.Component {
 class EngineRender extends React.Component {
   onMouseDown(e) {
     const engineRender = document.getElementById('engine-render');
-    const bcr = engineRender.getBoundingClinetRect();
+    const bcr = engineRender.getBoundingClientRect();
     window.postMessage({
       method: 'viewportMouseDown',
       x: e.clientX - bcr.x,
@@ -380,7 +380,7 @@ class EngineRender extends React.Component {
   }
   onMouseUp(e) {
     const engineRender = document.getElementById('engine-render');
-    const bcr = engineRender.getBoundingClinetRect();
+    const bcr = engineRender.getBoundingClientRect();
     window.postMessage({
       method: 'viewportMouseUp',
       x: e.clientX - bcr.x,
@@ -390,7 +390,7 @@ class EngineRender extends React.Component {
   }
   onClick(e) {
     const engineRender = document.getElementById('engine-render');
-    const bcr = engineRender.getBoundingClinetRect();
+    const bcr = engineRender.getBoundingClientRect();
     window.postMessage({
       method: 'viewportMouseClick',
       x: e.clientX - bcr.x,
@@ -400,7 +400,7 @@ class EngineRender extends React.Component {
   }
   onMouseMove(e) {
     const engineRender = document.getElementById('engine-render');
-    const bcr = engineRender.getBoundingClinetRect();
+    const bcr = engineRender.getBoundingClientRect();
     window.postMessage({
       method: 'viewportMouseMove',
       x: e.clientX - bcr.x,
@@ -409,7 +409,7 @@ class EngineRender extends React.Component {
   }
   onMouseWheel(e) {
     const engineRender = document.getElementById('engine-render');
-    const bcr = engineRender.getBoundingClinetRect();
+    const bcr = engineRender.getBoundingClientRect();
     window.postMessage({
       method: 'viewportMouseWheel',
       x: e.clientX - bcr.x,

--- a/ui/src/components/Engine.jsx
+++ b/ui/src/components/Engine.jsx
@@ -7,7 +7,9 @@ import '../css/engine.css';
 const _postViewportMessage = () => {
   const engineRender = document.getElementById('engine-render');
   const bcr = engineRender.getBoundingClientRect();
-  const viewport = [bcr.x/window.innerWidth, bcr.y/window.innerHeight, bcr.width/window.innerWidth, bcr.height/window.innerHeight];
+  // const position = [window.screenX + bcr.x, window.screenY + bcr.y];
+  // const viewport = [bcr.x/window.innerWidth, bcr.y/window.innerHeight, bcr.width/window.innerWidth, bcr.height/window.innerHeight];
+  const viewport = [window.screenX + bcr.x, window.screenY + bcr.y, bcr.width, bcr.height];
   window.postMessage({
     method: 'viewport',
     viewport,

--- a/ui/src/components/Engine.jsx
+++ b/ui/src/components/Engine.jsx
@@ -9,7 +9,8 @@ const _postViewportMessage = () => {
   const bcr = engineRender.getBoundingClientRect();
   // const position = [window.screenX + bcr.x, window.screenY + bcr.y];
   // const viewport = [bcr.x/window.innerWidth, bcr.y/window.innerHeight, bcr.width/window.innerWidth, bcr.height/window.innerHeight];
-  const viewport = [window.screenX + bcr.x, window.screenY + bcr.y, bcr.width, bcr.height];
+  // const viewport = [window.screenX + bcr.x, window.screenY + bcr.y, bcr.width, bcr.height];
+  const viewport = [bcr.x, bcr.y, bcr.width, bcr.height];
   window.postMessage({
     method: 'viewport',
     viewport,
@@ -36,7 +37,7 @@ class Engine extends React.Component {
     componentDidMount() {
       _postViewportMessage();
       window.addEventListener('resize', _postViewportMessage);
-      window.addEventListener('move', _postViewportMessage);
+      // window.addEventListener('move', _postViewportMessage);
 
       /* window.addEventListener('keydown', e => {
         console.log('iframe keydown ' + e.keyCode);

--- a/ui/src/components/Engine.jsx
+++ b/ui/src/components/Engine.jsx
@@ -392,7 +392,7 @@ class EngineRender extends React.Component {
     const engineRender = document.getElementById('engine-render');
     const bcr = engineRender.getBoundingClientRect();
     window.postMessage({
-      method: 'viewportMouseClick',
+      method: 'viewportClick',
       x: e.clientX - bcr.x,
       y: e.clientY - bcr.y,
       button: e.button,

--- a/ui/src/components/Engine.jsx
+++ b/ui/src/components/Engine.jsx
@@ -139,7 +139,7 @@ class Engine extends React.Component {
       e.stopPropagation();
     }
 
-    onEngineRenderClick() {
+    onEngineRenderFocus() {
       this.blur();
     }
 
@@ -344,7 +344,7 @@ class Engine extends React.Component {
           <Settings settings={this.state.settings === 'settings'} open={!!this.state.settings} close={() => this.openSettings(null)}/>
           <div className="engine-split">
             <div className="engine-left">
-              <div className="engine-render" id="engine-render" onClick={() => this.onEngineRenderClick()} />
+              <EngineRender onFocus={() => this.onEngineRenderFocus()}/>
               <Resizable
                 minWidth="200px"
                 // minHeight="100px"
@@ -370,6 +370,65 @@ class Engine extends React.Component {
       );
     }
   }
+
+class EngineRender extends React.Component {
+  onMouseDown(e) {
+    const engineRender = document.getElementById('engine-render');
+    const bcr = engineRender.getBoundingClinetRect();
+    window.postMessage({
+      method: 'viewportMouseDown',
+      x: e.clientX - bcr.x,
+      y: e.clientY - bcr.y,
+      button: e.button,
+    });
+  }
+  onMouseUp(e) {
+    const engineRender = document.getElementById('engine-render');
+    const bcr = engineRender.getBoundingClinetRect();
+    window.postMessage({
+      method: 'viewportMouseUp',
+      x: e.clientX - bcr.x,
+      y: e.clientY - bcr.y,
+      button: e.button,
+    });
+  }
+  onClick(e) {
+    const engineRender = document.getElementById('engine-render');
+    const bcr = engineRender.getBoundingClinetRect();
+    window.postMessage({
+      method: 'viewportMouseClick',
+      x: e.clientX - bcr.x,
+      y: e.clientY - bcr.y,
+      button: e.button,
+    });
+  }
+  onMouseMove(e) {
+    const engineRender = document.getElementById('engine-render');
+    const bcr = engineRender.getBoundingClinetRect();
+    window.postMessage({
+      method: 'viewportMouseMove',
+      x: e.clientX - bcr.x,
+      y: e.clientY - bcr.y,
+    });
+  }
+  onMouseWheel(e) {
+    const engineRender = document.getElementById('engine-render');
+    const bcr = engineRender.getBoundingClinetRect();
+    window.postMessage({
+      method: 'viewportMouseWheel',
+      x: e.clientX - bcr.x,
+      y: e.clientY - bcr.y,
+      deltaX: e.deltaX,
+      deltaY: e.deltaY,
+    });
+  }
+
+  render() {
+    return (
+      <div className="engine-render" id="engine-render" onClick={e => this.onClick(e)} onMouseDown={e => this.onMouseDown(e)} onMouseUp={e => this.onMouseUp(e)} onMouseMove={e => this.onMouseMove(e)} onMouseWheel={e => this.onMouseWheel(e)} />
+    );
+  }
+}
 
 class Settings extends React.Component {
   constructor(props) {

--- a/ui/src/components/Engine.jsx
+++ b/ui/src/components/Engine.jsx
@@ -37,17 +37,6 @@ class Engine extends React.Component {
     componentDidMount() {
       _postViewportMessage();
       window.addEventListener('resize', _postViewportMessage);
-      // window.addEventListener('move', _postViewportMessage);
-
-      /* window.addEventListener('keydown', e => {
-        console.log('iframe keydown ' + e.keyCode);
-      });
-      window.addEventListener('keyup', e => {
-        console.log('iframe keyup ' + e.keyCode);
-      });
-      window.addEventListener('keypress', e => {
-        console.log('iframe keypress ' + e.keyCode);
-      }); */
     }
 
     postMessage(action){

--- a/ui/src/css/App.css
+++ b/ui/src/css/App.css
@@ -1,7 +1,8 @@
 
 body {
   margin: 0;
-  background: #232526;  /* fallback for old browsers */
+  /* background: #232526;*/  /* fallback for old browsers */
+  background: transparent;
 }
 .nav-pills .nav-link.active{
   background-color: #B600DB;

--- a/ui/src/css/engine.css
+++ b/ui/src/css/engine.css
@@ -203,4 +203,5 @@
 #Engine .engine-render {
   flex: 1;
   background-color: rgba(0.0, 0.0, 0.0, 0.0);
+  user-select: none;
 }

--- a/ui/src/css/engine.css
+++ b/ui/src/css/engine.css
@@ -160,7 +160,7 @@
   bottom: 0;
   left: 0;
   right: 0;
-  /* background-color: rgba(0, 0, 0, 0.5); */
+  background-color: rgba(0, 0, 0, 0.5);
 }
 #Engine .settings > .settings-foreground {
   position: relative;

--- a/ui/src/css/engine.css
+++ b/ui/src/css/engine.css
@@ -202,5 +202,5 @@
 }
 #Engine .engine-render {
   flex: 1;
-  background-color: #0F0;
+  background-color: rgba(0.0, 0.0, 0.0, 0.0);
 }


### PR DESCRIPTION
This PR breaks the Studio render loop into two windows: the UI presented by Electron, and the 3D rendered by Exokit engine.

The Exokit engine window is aligned so that it appears to be part of the Electron window, although it is not -- the composition uses OS transparency to fake the effect.

The main reason for doing this is to make both Exokit rendering, and the HMTL UI rendering both fast regardless of the screen resolution used -- a 4K pixel transfer in _either_ direction is too slow to not drop frames.