### PR TITLE
[WIP]  Export to executable/package

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -8,7 +8,8 @@
     "react-dom": "^16.8.6",
     "react-markdown": "^4.0.8",
     "react-scripts": "3.0.0",
-    "yauzl": "^2.10.0"
+    "yauzl": "^2.10.0",
+    "yazl": "^2.5.1"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/ui/package.json
+++ b/ui/package.json
@@ -7,7 +7,8 @@
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "react-markdown": "^4.0.8",
-    "react-scripts": "3.0.0"
+    "react-scripts": "3.0.0",
+    "yauzl": "^2.10.0"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/ui/src/unzip.js
+++ b/ui/src/unzip.js
@@ -1,0 +1,109 @@
+var yauzl = require("yauzl");
+var path = require("path");
+var fs = require("fs");
+var util = require("util");
+var Transform = require("stream").Transform;
+
+var zipFilePath;
+var args = process.argv.slice(2);
+for (var i = 0; i < args.length; i++) {
+  var arg = args[i];
+  if (zipFilePath != null) throw new Error("too many arguments");
+  zipFilePath = arg;
+}
+
+
+function mkdirp(dir, cb) {
+  if (dir === ".") return cb();
+  fs.stat(dir, function(err) {
+    if (err == null) return cb(); // already exists
+
+    var parent = path.dirname(dir);
+    mkdirp(parent, function() {
+      process.stdout.write(dir.replace(/\/$/, "") + "/\n");
+      fs.mkdir(dir, cb);
+    });
+  });
+}
+
+
+yauzl.open(zipFilePath, {lazyEntries: true}, handleZipFile);
+
+function handleZipFile(err, zipfile) {
+  if (err) throw err;
+
+  // track when we've closed all our file handles
+  var handleCount = 0;
+  function incrementHandleCount() {
+    handleCount++;
+  }
+  function decrementHandleCount() {
+    handleCount--;
+    if (handleCount === 0) {
+      console.log("all input and output handles closed");
+    }
+  }
+
+  incrementHandleCount();
+  zipfile.on("close", function() {
+    console.log("closed input file");
+    decrementHandleCount();
+  });
+
+  zipfile.readEntry();
+  zipfile.on("entry", function(entry) {
+    if (/\/$/.test(entry.fileName)) {
+      // directory file names end with '/'
+      mkdirp(entry.fileName, function() {
+        if (err) throw err;
+        zipfile.readEntry();
+      });
+    } else {
+      // ensure parent directory exists
+      mkdirp(path.dirname(entry.fileName), function() {
+        zipfile.openReadStream(entry, function(err, readStream) {
+          if (err) throw err;
+          // report progress through large files
+          var byteCount = 0;
+          var totalBytes = entry.uncompressedSize;
+          var lastReportedString = byteCount + "/" + totalBytes + "  0%";
+          process.stdout.write(entry.fileName + "..." + lastReportedString);
+          function reportString(msg) {
+            var clearString = "";
+            for (var i = 0; i < lastReportedString.length; i++) {
+              clearString += "\b";
+              if (i >= msg.length) {
+                clearString += " \b";
+              }
+            }
+            process.stdout.write(clearString + msg);
+            lastReportedString = msg;
+          }
+          // report progress at 60Hz
+          var progressInterval = setInterval(function() {
+            reportString(byteCount + "/" + totalBytes + "  " + ((byteCount / totalBytes * 100) | 0) + "%");
+          }, 1000 / 60);
+          var filter = new Transform();
+          filter._transform = function(chunk, encoding, cb) {
+            byteCount += chunk.length;
+            cb(null, chunk);
+          };
+          filter._flush = function(cb) {
+            clearInterval(progressInterval);
+            reportString("");
+            // delete the "..."
+            process.stdout.write("\b \b\b \b\b \b\n");
+            cb();
+            zipfile.readEntry();
+          };
+
+          // pump file contents
+          var writeStream = fs.createWriteStream(entry.fileName);
+          incrementHandleCount();
+          writeStream.on("close", decrementHandleCount);
+          readStream.pipe(filter).pipe(writeStream);
+        });
+      });
+    }
+  });
+}

--- a/ui/src/zip.js
+++ b/ui/src/zip.js
@@ -1,0 +1,35 @@
+var yazl = require("yazl");
+var fs = require("fs");
+
+var zipfile = new yazl.ZipFile();
+var options = {compress: true, forceZip64Format: false};
+var addStrategy = "addFile";
+var verbose = true;
+
+var args = process.argv.slice(2);
+
+
+args.forEach(function(arg) {
+  // file thing
+  var stats = fs.statSync(arg);
+  if (stats.isFile()) {
+    if (verbose) console.log("addFile(" +
+                             JSON.stringify(arg) + ", " +
+                             JSON.stringify(arg) + ", " +
+                             JSON.stringify(options) + ");");
+    zipfile.addFile(arg, arg, options);
+  } else if (stats.isDirectory()) {
+    if (verbose) console.log("addEmptyDirectory(" +
+                             JSON.stringify(arg) + ", ");
+    zipfile.addEmptyDirectory(arg);
+  } else {
+    throw new Error("what is this: " + arg);
+  }
+});
+
+var stream = fs.createWriteStream("outexokit.apk");
+zipfile.outputStream.pipe(stream);
+
+zipfile.end({forceZip64Format: options.forceZip64Format}, function(finalSize) {
+  console.log("finalSize prediction: " + finalSize);
+});


### PR DESCRIPTION
This PR is to add #9, the ability in studio to `Export > <apk, mpk, dmg, exe, etc.>`.

- currently starting with the exporting to apk (oculus mobile) case

----------------------------------------
### To-do

- [x] unzip.js script
- [ ] package current studio sites to unzipped package
- [x] zip.js script
- [ ] application signing script
- [ ] studio UI to interact with/run scripts

----------------------------------------

### Notes
- hardcode the "layers" opened currently in studio to be opened by default in the apk/mpk
  - all layers URLs are opened on apk/mpk startup in something similar to realitytabs.html (without the UI menu)
- change the single startup site
- URLs or download the sites and pack with assets?

