### PR TITLE
Move right sidebar to settings background when settings is opened

### DIFF
--- a/ui/src/components/Engine.jsx
+++ b/ui/src/components/Engine.jsx
@@ -325,7 +325,6 @@ class Engine extends React.Component {
               </div>
             </div>
           </div>
-          <Settings settings={this.state.settings === 'settings'} open={!!this.state.settings} close={() => this.openSettings(null)}/>
           <div className="engine-split">
             <div className="engine-left">
               <EngineRender onFocus={() => this.onEngineRenderFocus()}/>
@@ -349,6 +348,7 @@ class Engine extends React.Component {
             </div>
             </Resizable>
           </div>
+          <Settings settings={this.state.settings === 'settings'} open={!!this.state.settings} close={() => this.openSettings(null)}/>
         </div>
       );
     }


### PR DESCRIPTION
This fixes a bug where the right sidebar was not going into the settings-background when the settings was open.

## Before
![studio04](https://user-images.githubusercontent.com/29695350/59827334-041f0100-92fe-11e9-8975-2f80be31354c.gif)

## After

![settingbackCapture](https://user-images.githubusercontent.com/29695350/59827333-03866a80-92fe-11e9-9fe5-c456b0527dbc.PNG)

